### PR TITLE
Fix target spec to fix run error

### DIFF
--- a/x86_64-aCore.json
+++ b/x86_64-aCore.json
@@ -1,12 +1,15 @@
 {
     "llvm-target": "x86_64-unknown-none",
-    "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+    "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
     "arch": "x86_64",
     "target-endian": "little",
     "target-pointer-width": "64",
     "target-c-int-width": "32",
     "os": "none",
+    "executables": true,
     "linker-flavor": "ld.lld",
     "linker": "rust-lld",
-    "executables": true
+    "panic-strategy": "abort",
+    "disable-redzone": true,
+    "features": "-mmx,-sse,+soft-float"
 }


### PR DESCRIPTION
This updates the target specification to that of https://os.phil-opp.com/minimal-rust-kernel/#putting-it-together. Mainly, it disables the SSE/MMX features, which caused the invalid opcode exception before.